### PR TITLE
Add transform funcs to processors and utilise to build url where querystring present

### DIFF
--- a/resources/builder-config.yaml
+++ b/resources/builder-config.yaml
@@ -16,6 +16,7 @@ processors:
   - gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.128.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor v0.128.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor v0.128.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor v0.128.0
 
 receivers:
   - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.128.0

--- a/resources/collector-config.yaml
+++ b/resources/collector-config.yaml
@@ -40,7 +40,7 @@ service:
   pipelines:
     traces:
       receivers: [otlp]
-      processors: [batch, transform]
+      processors: [batch,transform]
       exporters: [debug]
     metrics:
       receivers: [otlp]

--- a/resources/collector-config.yaml
+++ b/resources/collector-config.yaml
@@ -5,8 +5,23 @@ receivers:
         endpoint: 0.0.0.0:4317
       http:
         endpoint: 0.0.0.0:4318
+
 processors:
   batch:
+  transform:
+    trace_statements:
+      - set(
+          span.attributes["http.url"],
+          Concat([
+            span.attributes["url.scheme"],
+            "://",
+            span.attributes["server.address"],
+            span.attributes["url.path"],
+            "?",
+            span.attributes["url.query"]
+          ], "")
+        )
+        where span.attributes["url.query"] != nil and span.attributes["url.query"] != ""
 
 extensions:
   health_check:
@@ -25,7 +40,7 @@ service:
   pipelines:
     traces:
       receivers: [otlp]
-      processors: [batch]
+      processors: [batch, transform]
       exporters: [debug]
     metrics:
       receivers: [otlp]
@@ -35,4 +50,3 @@ service:
       receivers: [otlp]
       processors: [batch]
       exporters: [debug]
-

--- a/terraform/groups/ecs-service/gateway-otel-collector-config.yaml
+++ b/terraform/groups/ecs-service/gateway-otel-collector-config.yaml
@@ -14,6 +14,20 @@ processors:
     send_batch_size: 50
   batch/metrics:
     timeout: 60s
+  transform:
+    trace_statements:
+      - set(
+          span.attributes["http.url"],
+          Concat([
+            span.attributes["url.scheme"],
+            "://",
+            span.attributes["server.address"],
+            span.attributes["url.path"],
+            "?",
+            span.attributes["url.query"]
+          ], "")
+        )
+        where span.attributes["url.query"] != nil and span.attributes["url.query"] != ""
 
   filter/drop_healthcheck_attributes:
     traces:
@@ -70,7 +84,7 @@ service:
   pipelines:
     traces:
       receivers: [otlp]
-      processors: [batch/traces,filter/drop_healthcheck_attributes,tail_sampling]
+      processors: [batch/traces,filter/drop_healthcheck_attributes,tail_sampling,transform]
       exporters: [debug,awsxray]
     metrics:
       receivers: [otlp]


### PR DESCRIPTION
https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.128.0/exporter/awsxrayexporter/internal/translator/http.go#L51

The xray exporter will accept either http.url or url.full

span attributes output
http.url | "http://api.chs.local/company/00006400/confirmation-statement/paid?payment_period_made_up_to_date=2022-02-23"